### PR TITLE
Update README for clarity and pin some package versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,26 @@
 
 This repository contains parity readout simulation code and scripts for generating data-driven figures for the published paper "Interferometric Single-Shot Parity Measurement in InAs-Al Hybrid Devices" by Microsoft Azure Quantum.
 * Preprint: [arXiv:2401.09549](https://arxiv.org/abs/2401.09549)
-* Peer-reviewed publication : To appear in Nature (February 2025)
+* Peer-reviewed publication: [Nature 638, 651–655 (2025).](https://doi.org/10.1038/s41586-024-08445-2)
 
 All references to figure numbers in this repository refer to the peer-reviewed revision of the paper published in Nature which may differ from the preprint.
 
+## Requirements
+
+The data analysis and figure generating scripts in this repository were run using Python 3.10.9 and the environment specified in [`uv.lock`](uv.lock) (we also provide a [`requirements.txt`](requirements.txt) for advanced users
+who do not wish to use `uv`).
+
+The simulation data and figures were generated using Julia `v1.10.8`. See [ParityReadoutSimulator/README.md](ParityReadoutSimulator/README.md) for additional information on the `ParityReadoutSimulator` and Julia environment requirements.
+
+The quickest way to reproduce the environment used for data analysis and figure generation is to use the
+tool [`uv`](https://docs.astral.sh/uv/), which can be installed by following [these instructions](https://docs.astral.sh/uv/getting-started/installation/).
+
+Once `uv` is installed, running the following commands will install the necessary software into an isolated
+environment, and activate that environment for future use:
+```bash
+uv sync # download Python 3.10.9, and all dependencies, creating a virtual environment with everything installed
+source .venv/bin/activate  # activate the virtual environment
+```
 
 ## Data
 
@@ -70,22 +86,12 @@ As a result, the minimal datasets you need to download from [Zenodo](https://zen
 
 If downloaded manually, you should put these files in a directory named `data` and then run [`prepare_data.py`](prepare_data.py) to extract the files into their respective locations automatically.
 
-## Requirements
+## Minimal code for reproducing measured figures
 
-The data analysis and figure generating scripts in this repository were run using Python 3.10.9 and the environment specified in [`uv.lock`](uv.lock) (we also provide a [`requirements.txt`](requirements.txt) for advanced users
-who do not wish to use `uv`).
+If you are only interested in reproducing the figures, you need to follow the instructions in [Requirements](#requirements)
+and downloading the minimal datasets when asked by `prepare_data.py` (i.e. run `python prepare_data.py --download-minimal`).
 
-The simulation data and figures were generated using Julia `v1.10.8`. See [ParityReadoutSimulator/README.md](ParityReadoutSimulator/README.md) for additional information on the `ParityReadoutSimulator` and Julia environment requirements.
-
-The quickest way to reproduce the environment used for data analysis and figure generation is to use the
-tool [`uv`](https://docs.astral.sh/uv/), which can be installed by following [these instructions](https://docs.astral.sh/uv/getting-started/installation/).
-
-Once `uv` is installed, running the following commands will install the necessary software into an isolated
-environment, and activate that environment for future use:
-```bash
-uv sync # download Python 3.10.9, and all dependencies, creating a virtual environment with everything installed
-source .venv/bin/activate  # activate the virtual environment
-```
+Now that the data and environment are ready, you can run `jupytext --execute measured_analysis_figures/figure*.md`
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,30 @@ This repository contains parity readout simulation code and scripts for generati
 
 All references to figure numbers in this repository refer to the peer-reviewed revision of the paper published in Nature which may differ from the preprint.
 
+If you are interested in generating the plots in the paper with minimal interaction with this repo, look at the sections [Requirements](#requirements), [Minimal Data to Reproduce Figures](#minimal-data-to-reproduce-figures) and [Minimal Code for Reproducing Measured Figures](#minimal-code-for-reproducing-measured-figures).
+
+---
+
+**Table of Contents**
+* [Requirements](#requirements)
+* [Data](#data)
+    + [Data Paths](#data-paths)
+    + [Minimal Data to Reproduce Figures](#minimal-data-to-reproduce-figures)
+* [Reproducing Figures in the Paper](#reproducing-figures-in-the-paper)
+    + [Minimal code for reproducing measured figures](#minimal-code-for-reproducing-measured-figures)
+    + [Reproducing Simulation Figures](#reproducing-simulation-figures)
+    + [More advanced analyses/testing](#more-advanced-analysestesting)
+* [Modules](#modules)
+    + [1. `cq_conversion`](#1-cq_conversion)
+    + [2. `measured_analysis_figures`](#2-measured_analysis_figures)
+        - [Additional Requirements](#additional-requirements)
+    + [3. `ParityReadoutSimulator`](#3-parityreadoutsimulator)
+    + [4. `thermometry`](#4-thermometry)
+* [Microsoft Open Source Code of Conduct](#microsoft-open-source-code-of-conduct)
+* [Trademarks](#trademarks)
+
+---
+
 ## Requirements
 
 The data analysis and figure generating scripts in this repository were run using Python 3.10.9 and the environment specified in [`uv.lock`](uv.lock) (we also provide a [`requirements.txt`](requirements.txt) for advanced users
@@ -28,11 +52,11 @@ source .venv/bin/activate  # activate the virtual environment
 Measured and simulated data is available in the accompanying dataset on [Zenodo](https://zenodo.org/records/14804380). You can download it manually and point to the data
 folder in [paths.py](paths.py), see [Data Paths](#data-paths) for more info.
 
-For convenience, you can also run [`prepare_data.py`](prepare_data.py) python script, which will download the data from Zenodo
+For convenience, you can also run the [`prepare_data.py`](prepare_data.py) python script, which will download the data from Zenodo
 and put it in a folder called `data`.
 
 ### Data Paths
-As an interface for all our code, all raw and generated data is organized into the following folder variables:
+As an interface for all our code, all raw and generated data are organized into the following folder variables:
 
 - `DATA_FOLDER`: Variable for a folder containing four subdirectories outlined below
 - `RAW_DATA_FOLDER`: Variable for a folder containing all measured data to be used for analysis and plotting.
@@ -45,7 +69,7 @@ a folder named `data` in the root of this repository. These variables are propag
 scripts that rely on measured, simulated or CQ converted data.
 
 We provided a python script [`prepare_data.py`](prepare_data.py) that (optionally) downloads the data from zenodo
-and automatically generates this target directory structure. When you execute the script, you will have the option to
+and automatically generates this target directory structure. When you execute this script, you will have the option to
 download all our datasets (~150Gb), a minimal subset of datasets to reproduce the plots in the paper (~6GB) or manually
 download the data. After that the script will unpack the zip files into their target directory.
 In case this fails (e.g. due to a different OS), the zip outputs on the
@@ -75,7 +99,8 @@ except for `figureS6_dot_tuneup.md`, `figureS7_tgp2_tuneup.md` and `figureS18_de
 
 Some of the raw datasets (all datasets labelled `run_name.zip`) contain timetraces that were left uncoarsened and as a result, are really large. If you are only interested
 in using the coarsened data to regenerate a figure, you can download the `converted_data.zip` file from zenodo. This zip contains all the CQ converted RF measurements used to
-generate the figures (see note in previous subsection).
+generate the figures (see note in previous subsection
+for more details).
 
 As a result, the minimal datasets you need to download from [Zenodo](https://zenodo.org/records/14804380) to reproduce all figures in the paper are:
 - `simulated.zip` (1.0 GB)
@@ -86,12 +111,24 @@ As a result, the minimal datasets you need to download from [Zenodo](https://zen
 
 If downloaded manually, you should put these files in a directory named `data` and then run [`prepare_data.py`](prepare_data.py) to extract the files into their respective locations automatically.
 
-## Minimal code for reproducing measured figures
+## Reproducing Figures in the Paper
+
+### Minimal code for reproducing measured figures
 
 If you are only interested in reproducing the figures, you need to follow the instructions in [Requirements](#requirements)
 and downloading the minimal datasets when asked by `prepare_data.py` (i.e. run `python prepare_data.py --download-minimal`).
 
 Now that the data and environment are ready, you can run `jupytext --execute measured_analysis_figures/figure*.md`
+
+### Reproducing Simulation Figures
+
+To reproduce simulation figures, follow the instructions in [ParityReadoutSimulator/README.md](ParityReadoutSimulator/README.md)
+to setup the environment. You should then be able to reproduce the simulated figures and reference datasets by running through
+the notebooks manually. You can also do the following to automate the generation of all of the below.
+
+### More advanced analyses/testing
+
+For more advanced users, refer to the below section on the various [Modules](#modules) in this repo.
 
 ## Modules
 

--- a/prepare_data.py
+++ b/prepare_data.py
@@ -57,9 +57,14 @@ minimal_files = [
 def process_file(filename):
     full_path = os.path.join(basepath, filename)
     if not is_zipfile(full_path):
-        print(
-            f"Cannot find {full_path}, some files may be missing for the full analysis."
-        )
+        if filename in minimal_files:
+            print(
+                f"Cannot find {full_path} required for reproducing of the paper figures"
+            )
+        else:
+            print(
+                f"Skip optional {full_path}, needed for reproducing of Cq converted data"
+            )
     else:
         print(f"Unpacking {full_path}")
         with ZipFile(full_path, "r") as myzip:
@@ -102,8 +107,8 @@ already downloaded the data, you can skip this step.
 
         if minimal_dataset is None:
             minimal_dataset = input(
-                """\n\nDo you want to download the minimal datasets required reproduce the paper (~6GB)?
-Answer yes to download {converted_data.zip, simulated.zip, tgp2_tuneup.zip} and no
+                f"""\n\nDo you want to download the minimal datasets required reproduce the paper (~6GB)?
+Answer yes (Y) to download {minimal_files} and no (n)
 to download all datasets (~150Gb+).
 [Y/n] """
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,8 +14,8 @@ dependencies = [
     "jupyter>=1.1.1",
     "jupytext>=1.16.6",
     "lmfit>=1.2.2",
-    "matplotlib>=3.7.0",
-    "numpy>=1.23.5",
+    "matplotlib==3.9.0",
+    "numpy==1.23.5",
     "opencv-python==4.7.0.72",
     "pymc==5.10.3",
     "scikit-image>=0.22.0",
@@ -25,6 +25,6 @@ dependencies = [
     "sympy>=1.11.1",
     "tqdm>=4.64.1",
     "uncertainties>=3.1.7",
-    "xarray>=2023.4.1",
+    "xarray==2023.4.1",
     "xarray-einstats>=0.7.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.12' and sys_platform == 'darwin'",
@@ -1438,7 +1439,7 @@ wheels = [
 
 [[package]]
 name = "matplotlib"
-version = "3.7.0"
+version = "3.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "contourpy" },
@@ -1451,24 +1452,26 @@ dependencies = [
     { name = "pyparsing" },
     { name = "python-dateutil" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/65/c2/34158ff731a12802228434e8d17d2ebb5097394ab9d065205cc262cf2a6f/matplotlib-3.7.0.tar.gz", hash = "sha256:8f6efd313430d7ef70a38a3276281cb2e8646b3a22b3b21eb227da20e15e6813", size = 36346055 }
+sdist = { url = "https://files.pythonhosted.org/packages/c5/a4/a7236bf8b0137deff48737c6ccf2154ef4486e57c6a5b7c309bf515992bd/matplotlib-3.9.0.tar.gz", hash = "sha256:e6d29ea6c19e34b30fb7d88b7081f869a03014f66fe06d62cc77d5a6ea88ed7a", size = 36069890 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a9/5c/6ef113407b0bd99447d2a5bee2b160b47e5bba3e3611bbd922ad944d7451/matplotlib-3.7.0-cp310-cp310-macosx_10_12_universal2.whl", hash = "sha256:3da8b9618188346239e51f1ea6c0f8f05c6e218cfcc30b399dd7dd7f52e8bceb", size = 8310802 },
-    { url = "https://files.pythonhosted.org/packages/ce/06/847aa3ceb38da59c7ad4fc3b98695e15acc6cef426a14d3b382cb782c591/matplotlib-3.7.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:c0592ba57217c22987b7322df10f75ef95bc44dce781692b4b7524085de66019", size = 7426570 },
-    { url = "https://files.pythonhosted.org/packages/ca/68/af21f4d62f42368c13bc8bbf3bbfb072fd5a944bbf9906c805a91436873f/matplotlib-3.7.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:21269450243d6928da81a9bed201f0909432a74e7d0d65db5545b9fa8a0d0223", size = 7330089 },
-    { url = "https://files.pythonhosted.org/packages/17/d3/776f1b1cb8d8371ae3dbafa478295acf8415e612ca7f2eeeb416e8d1e49d/matplotlib-3.7.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eb2e76cd429058d8954121c334dddfcd11a6186c6975bca61f3f248c99031b05", size = 11343295 },
-    { url = "https://files.pythonhosted.org/packages/9d/57/ac31c1d9cea4b13dcfae90de9f0b1c8264e1ffff193c6346eab47cd4e1cb/matplotlib-3.7.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:de20eb1247725a2f889173d391a6d9e7e0f2540feda24030748283108b0478ec", size = 11447652 },
-    { url = "https://files.pythonhosted.org/packages/05/da/0b3bdae60e27b99d22a044f63de323988c7343b787734ca76e41de48cf9b/matplotlib-3.7.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c5465735eaaafd1cfaec3fed60aee776aeb3fd3992aa2e49f4635339c931d443", size = 11569208 },
-    { url = "https://files.pythonhosted.org/packages/de/bd/fa12a97b384805fcbfe1ec0ab283e8f284210068fde2514277ef41082bc5/matplotlib-3.7.0-cp310-cp310-win32.whl", hash = "sha256:092e6abc80cdf8a95f7d1813e16c0e99ceda8d5b195a3ab859c680f3487b80a2", size = 7331451 },
-    { url = "https://files.pythonhosted.org/packages/b3/58/20216183f03327d5799f55519876f176174167a8f6712e4cadd42eab909c/matplotlib-3.7.0-cp310-cp310-win_amd64.whl", hash = "sha256:4f640534ec2760e270801056bc0d8a10777c48b30966eef78a7c35d8590915ba", size = 7640446 },
-    { url = "https://files.pythonhosted.org/packages/04/81/4a7ceb30d60c5663a183cb14b75315b52a29cf65ce0954ba5a7165a8f6a6/matplotlib-3.7.0-cp311-cp311-macosx_10_12_universal2.whl", hash = "sha256:f336e7014889c38c59029ebacc35c59236a852e4b23836708cfd3f43d1eaeed5", size = 8310821 },
-    { url = "https://files.pythonhosted.org/packages/50/15/1d28dd65759798035aafb63fbe2844f33b1846a387b485e62bbbb98c71ca/matplotlib-3.7.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:3a10428d4f8d1a478ceabd652e61a175b2fdeed4175ab48da4a7b8deb561e3fa", size = 7425633 },
-    { url = "https://files.pythonhosted.org/packages/32/2e/3e164ef3608338b436fd2c3d8e363583e0882749b6bbc5071c407f345f84/matplotlib-3.7.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:46ca923e980f76d34c1c633343a72bb042d6ba690ecc649aababf5317997171d", size = 7330046 },
-    { url = "https://files.pythonhosted.org/packages/db/0f/7feb92afa40d0919e8ed729351ed0df3030351886a0a2e30f723b2cd3dac/matplotlib-3.7.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c849aa94ff2a70fb71f318f48a61076d1205c6013b9d3885ade7f992093ac434", size = 11346980 },
-    { url = "https://files.pythonhosted.org/packages/ba/95/26ebd4d1613296d50fae5c58779273adfa24eadf16fe6da9f44bec61935d/matplotlib-3.7.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:827e78239292e561cfb70abf356a9d7eaf5bf6a85c97877f254009f20b892f89", size = 11451124 },
-    { url = "https://files.pythonhosted.org/packages/6f/07/8c77dd5538d80023f64510312a52df5f463b04450915f6636ee820e5ea95/matplotlib-3.7.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:691ef1f15360e439886186d0db77b5345b24da12cbc4fc57b26c4826db4d6cab", size = 11572862 },
-    { url = "https://files.pythonhosted.org/packages/93/15/d079a47f516b66b506c73eecfee4f7c5e613be6dce643e5494b4bdb8aa4b/matplotlib-3.7.0-cp311-cp311-win32.whl", hash = "sha256:21a8aeac39b4a795e697265d800ce52ab59bdeb6bb23082e2d971f3041074f02", size = 7330693 },
-    { url = "https://files.pythonhosted.org/packages/2c/63/8e406cf7fd0e56be8a9cebc8434ff609b9fc246edb9b8ba533e56c871778/matplotlib-3.7.0-cp311-cp311-win_amd64.whl", hash = "sha256:01681566e95b9423021b49dea6a2395c16fa054604eacb87f0f4c439750f9114", size = 7640374 },
+    { url = "https://files.pythonhosted.org/packages/03/a0/669c37c6e6737de909c19eb30d7b17d1d6be6d896aa2f5dc63e66231b7f4/matplotlib-3.9.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:2bcee1dffaf60fe7656183ac2190bd630842ff87b3153afb3e384d966b57fe56", size = 7883911 },
+    { url = "https://files.pythonhosted.org/packages/f7/1f/a0f1a692af13b85335a9d7bd226fc0cae8d0062f1fb940980bc9b38d3b5c/matplotlib-3.9.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:3f988bafb0fa39d1074ddd5bacd958c853e11def40800c5824556eb630f94d3b", size = 7765903 },
+    { url = "https://files.pythonhosted.org/packages/fc/3d/58182994c955ff2fc722f883e96ad9de3439d3ead668fce33ad1c3fe4242/matplotlib-3.9.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fe428e191ea016bb278758c8ee82a8129c51d81d8c4bc0846c09e7e8e9057241", size = 8183679 },
+    { url = "https://files.pythonhosted.org/packages/a7/68/16e7b9154fae61fb29f0f3450b39b855b89e6d2c598d67302e70f96883af/matplotlib-3.9.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eaf3978060a106fab40c328778b148f590e27f6fa3cd15a19d6892575bce387d", size = 8296303 },
+    { url = "https://files.pythonhosted.org/packages/ef/66/ad8d69aa13fd6e1b09fe7b91b512d07eaf175a0b0e7c4bcba87e8d2e01d6/matplotlib-3.9.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:2e7f03e5cbbfacdd48c8ea394d365d91ee8f3cae7e6ec611409927b5ed997ee4", size = 8594927 },
+    { url = "https://files.pythonhosted.org/packages/b9/55/6138ad64c789bad13d18e0240da75e73dbd364fdc0aa670fff87a5eef5ab/matplotlib-3.9.0-cp310-cp310-win_amd64.whl", hash = "sha256:13beb4840317d45ffd4183a778685e215939be7b08616f431c7795276e067463", size = 7954080 },
+    { url = "https://files.pythonhosted.org/packages/09/49/569b50eb5e5a75b61f7a0bacb6029e9ea9c8a1190df55a39a31789244e09/matplotlib-3.9.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:063af8587fceeac13b0936c42a2b6c732c2ab1c98d38abc3337e430e1ff75e38", size = 7893678 },
+    { url = "https://files.pythonhosted.org/packages/f4/b4/c1700c8b2ff8d379c187f37055e61bd7a611eb2c544466600a7734793d54/matplotlib-3.9.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9a2fa6d899e17ddca6d6526cf6e7ba677738bf2a6a9590d702c277204a7c6152", size = 7775027 },
+    { url = "https://files.pythonhosted.org/packages/bc/9e/b09513717f60071fefcb28c7c783aa658f939f3d4ba1cefb6c05138c6657/matplotlib-3.9.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:550cdda3adbd596078cca7d13ed50b77879104e2e46392dcd7c75259d8f00e85", size = 8192694 },
+    { url = "https://files.pythonhosted.org/packages/41/f1/115e7c79b4506b4f0533acba742babd9718ff92eeca6d4205843173b6173/matplotlib-3.9.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:76cce0f31b351e3551d1f3779420cf8f6ec0d4a8cf9c0237a3b549fd28eb4abb", size = 8307002 },
+    { url = "https://files.pythonhosted.org/packages/7a/a2/5c1a64d188c4cae7368ebb8c28a354e3f262cb86b28c38ffa6ee3ad532ba/matplotlib-3.9.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:c53aeb514ccbbcbab55a27f912d79ea30ab21ee0531ee2c09f13800efb272674", size = 8600548 },
+    { url = "https://files.pythonhosted.org/packages/c6/c8/6936e8c7b279a5abac82f399d8d72ac25da530cf5f78a0e40063e492558c/matplotlib-3.9.0-cp311-cp311-win_amd64.whl", hash = "sha256:a5be985db2596d761cdf0c2eaf52396f26e6a64ab46bd8cd810c48972349d1be", size = 7963606 },
+    { url = "https://files.pythonhosted.org/packages/af/43/54b7dfd91ed33da92973dc5d50231ef7b2d0622c8ae72babbad26bc1a319/matplotlib-3.9.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:c79f3a585f1368da6049318bdf1f85568d8d04b2e89fc24b7e02cc9b62017382", size = 7884612 },
+    { url = "https://files.pythonhosted.org/packages/4c/88/15bbb864b0d871707294ff325f9ffd0dfa486db2637eb34dd5f8dcf5b9bf/matplotlib-3.9.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:bdd1ecbe268eb3e7653e04f451635f0fb0f77f07fd070242b44c076c9106da84", size = 7769852 },
+    { url = "https://files.pythonhosted.org/packages/57/af/8ed9b852fc041fc5bd101f9964682874ccbf24f9c08323edee6a1600eb04/matplotlib-3.9.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d38e85a1a6d732f645f1403ce5e6727fd9418cd4574521d5803d3d94911038e5", size = 8185646 },
+    { url = "https://files.pythonhosted.org/packages/f4/ff/da311c1e679eed54d3aed67754a4e859bd3b773060c2fa187962e60fcb85/matplotlib-3.9.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0a490715b3b9984fa609116481b22178348c1a220a4499cda79132000a79b4db", size = 8298411 },
+    { url = "https://files.pythonhosted.org/packages/db/8c/1014baa6776503914865d87e1e8a803ee9faa7b722ca5e655463b79c966e/matplotlib-3.9.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8146ce83cbc5dc71c223a74a1996d446cd35cfb6a04b683e1446b7e6c73603b7", size = 8591196 },
+    { url = "https://files.pythonhosted.org/packages/17/91/febbb6c1063ae05a62fdbe038c2917b348b1b35f0482cee4738e6870a44a/matplotlib-3.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:d91a4ffc587bacf5c4ce4ecfe4bcd23a4b675e76315f2866e588686cc97fccdf", size = 7968581 },
 ]
 
 [[package]]
@@ -1891,8 +1894,8 @@ requires-dist = [
     { name = "jupyter", specifier = ">=1.1.1" },
     { name = "jupytext", specifier = ">=1.16.6" },
     { name = "lmfit", specifier = ">=1.2.2" },
-    { name = "matplotlib", specifier = ">=3.7.0" },
-    { name = "numpy", specifier = ">=1.23.5" },
+    { name = "matplotlib", specifier = "==3.9.0" },
+    { name = "numpy", specifier = "==1.23.5" },
     { name = "opencv-python", specifier = "==4.7.0.72" },
     { name = "pymc", specifier = "==5.10.3" },
     { name = "scikit-image", specifier = ">=0.22.0" },
@@ -1902,7 +1905,7 @@ requires-dist = [
     { name = "sympy", specifier = ">=1.11.1" },
     { name = "tqdm", specifier = ">=4.64.1" },
     { name = "uncertainties", specifier = ">=3.1.7" },
-    { name = "xarray", specifier = ">=2023.4.1" },
+    { name = "xarray", specifier = "==2023.4.1" },
     { name = "xarray-einstats", specifier = ">=0.7.0" },
 ]
 


### PR DESCRIPTION
- Pinned packages to avoid matplotlib PDF rendering problem with TGP figures
- Added a TOC to readme and section on what code to run to reproduce what types of figures
- Updated `prepare_data.py` to give more accurate print messages and removed unused dependencies